### PR TITLE
fix reading stream client

### DIFF
--- a/src/board_driver.cpp
+++ b/src/board_driver.cpp
@@ -221,7 +221,7 @@ String getMoveInput(void) {
         }
       }
     }
-    if (StreamClient.available() & board_startupType == "WiFi"){
+    if (StreamClient.available() && board_startupType == "WiFi"){
       moveStreamHandler();
     }
   }
@@ -261,7 +261,7 @@ String getMoveInput(void) {
         }
       }
     }
-    if (StreamClient.available() & board_startupType == "WiFi"){
+    if (StreamClient.available() && board_startupType == "WiFi"){
       moveStreamHandler();
     }
   }


### PR DESCRIPTION
If I wait too long with a move, more and more data gets written into the stream buffer because Lichess sends something like a keep-alive message, which in my case is 6 characters long. As a result, the moveStreamHandler() method is never called.
When a move is finally made, it takes too long, and both my last move and the opponent's move are read at once, but only the first JSON object is processed.
After that, the game can't really continue because it's waiting for a new message from Lichess, which never arrives.